### PR TITLE
Add entry point access and test

### DIFF
--- a/examples/prepare_det_env.py
+++ b/examples/prepare_det_env.py
@@ -2,7 +2,6 @@ import datetime
 
 from bluesky.run_engine import RunEngine
 from bluesky.callbacks import best_effort
-from bluesky.utils import install_kicker
 
 import databroker
 from databroker import Broker
@@ -29,7 +28,6 @@ db.reg.register_handler('srw', SRWFileHandler, overwrite=True)
 db.reg.register_handler('SIREPO_FLYER', SRWFileHandler, overwrite=True)
 
 plt.ion()
-install_kicker()
 
 root_dir = '/tmp/sirepo_flyer_data'
 _ = make_dir_tree(datetime.datetime.now().year, base_path=root_dir)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'console_scripts': [
             # 'command = some.module:some_function',
         ],
-        "intake.catalogs": ["local=local:local_catalog_instance"],
+        "intake.catalogs": ["local = sirepo_bluesky:sirepo_bluesky_catalog_instance"],
     },
     include_package_data=True,
     package_data={

--- a/sirepo_bluesky/__init__.py
+++ b/sirepo_bluesky/__init__.py
@@ -1,3 +1,13 @@
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+import intake
+
+# Look up a driver class by its name in the registry.
+catalog_class = intake.registry["bluesky-mongo-normalized-catalog"]
+
+sirepo_bluesky_catalog_instance = catalog_class(
+    metadatastore_db="mongodb://localhost:27017/md",
+    asset_registry_db="mongodb://localhost:27017/ar",
+)

--- a/sirepo_bluesky/tests/test_entry_pt.py
+++ b/sirepo_bluesky/tests/test_entry_pt.py
@@ -1,15 +1,5 @@
 from databroker import Broker
-#from bluesky import RunEngine
-#from bluesky.callbacks.best_effort import BestEffortCallback
 
-
-#RE = RunEngine()
-#bec = BestEffortCallback()
-#RE.subscribe(bec)
-#db = Broker.named('bluesky-cartpole')
-#db = Broker.named('sirepo-bluesky')
 def test_broker():
 	db = Broker.named("local")
-
-#RE.subscribe(db.insert)
 

--- a/sirepo_bluesky/tests/test_entry_pt.py
+++ b/sirepo_bluesky/tests/test_entry_pt.py
@@ -1,0 +1,15 @@
+from databroker import Broker
+#from bluesky import RunEngine
+#from bluesky.callbacks.best_effort import BestEffortCallback
+
+
+#RE = RunEngine()
+#bec = BestEffortCallback()
+#RE.subscribe(bec)
+#db = Broker.named('bluesky-cartpole')
+#db = Broker.named('sirepo-bluesky')
+def test_broker():
+	db = Broker.named("local")
+
+#RE.subscribe(db.insert)
+


### PR DESCRIPTION
Added an entry point in the `setup.py` file. This avoids the use of a `local.yml` file. The test is included in the tests directory to ensure DataBroker can find the local entry point. The `__init__.py` file was also updated to include necessary Information for the entry point. 