### PR TITLE
Use collect_asset_docs() for resource and datum documents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   - flake8  # Enforce code style ('relaxed' line length limit is set in .flake8 config file).
   - |
     if [ ! -z "$USE_DOCKER" ]; then
-        container_id=$(docker run -d -t --rm -e SIREPO_AUTH_METHODS=bluesky:guest -e SIREPO_AUTH_BLUESKY_SECRET=bluesky -e SIREPO_SRDB_ROOT=/sirepo -e SIREPO_COOKIE_IS_SECURE=false -p 8000:8000 -v $PWD/sirepo_bluesky/tests/SIREPO_SRDB_ROOT:/SIREPO_SRDB_ROOT:ro,z radiasoft/sirepo:20200220.135917 bash -l -c "mkdir -v -p /sirepo/user/ && cp -Rv /SIREPO_SRDB_ROOT/* /sirepo/user/ && sirepo service http")
+        container_id=$(docker run -d -t --init --rm -u vagrant --name sirepo -e SIREPO_AUTH_METHODS=bluesky:guest -e SIREPO_AUTH_BLUESKY_SECRET=bluesky -e SIREPO_SRDB_ROOT=/sirepo -e SIREPO_COOKIE_IS_SECURE=false -p 8000:8000 -v $PWD/sirepo_bluesky/tests/SIREPO_SRDB_ROOT:/SIREPO_SRDB_ROOT:ro,z radiasoft/sirepo:beta bash -l -c "mkdir -v -p /sirepo/user/ && cp -Rv /SIREPO_SRDB_ROOT/* /sirepo/user/ && sirepo service http")
         coverage run -m pytest -vvvv -m "docker"  # Run the tests and check for test coverage.
         docker logs $container_id
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   - flake8  # Enforce code style ('relaxed' line length limit is set in .flake8 config file).
   - |
     if [ ! -z "$USE_DOCKER" ]; then
-        container_id=$(docker run -d -t --rm -e SIREPO_AUTH_METHODS=bluesky:guest -e SIREPO_AUTH_BLUESKY_SECRET=bluesky -e SIREPO_SRDB_ROOT=/sirepo -e SIREPO_COOKIE_IS_SECURE=false -p 8000:8000 -v $PWD/sirepo_bluesky/tests/SIREPO_SRDB_ROOT:/SIREPO_SRDB_ROOT:ro,z radiasoft/sirepo:beta bash -c "mkdir -v -p /sirepo/user/ && cp -Rv /SIREPO_SRDB_ROOT/* /sirepo/user/ && /home/vagrant/.pyenv/shims/sirepo service http")
+        container_id=$(docker run -d -t --rm -e SIREPO_AUTH_METHODS=bluesky:guest -e SIREPO_AUTH_BLUESKY_SECRET=bluesky -e SIREPO_SRDB_ROOT=/sirepo -e SIREPO_COOKIE_IS_SECURE=false -p 8000:8000 -v $PWD/sirepo_bluesky/tests/SIREPO_SRDB_ROOT:/SIREPO_SRDB_ROOT:ro,z radiasoft/sirepo:20200220.135917 bash -l -c "mkdir -v -p /sirepo/user/ && cp -Rv /SIREPO_SRDB_ROOT/* /sirepo/user/ && sirepo service http")
         coverage run -m pytest -vvvv -m "docker"  # Run the tests and check for test coverage.
         docker logs $container_id
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   - flake8  # Enforce code style ('relaxed' line length limit is set in .flake8 config file).
   - |
     if [ ! -z "$USE_DOCKER" ]; then
-        container_id=$(docker run -d -t --init --rm -u vagrant --name sirepo -e SIREPO_AUTH_METHODS=bluesky:guest -e SIREPO_AUTH_BLUESKY_SECRET=bluesky -e SIREPO_SRDB_ROOT=/sirepo -e SIREPO_COOKIE_IS_SECURE=false -p 8000:8000 -v $PWD/sirepo_bluesky/tests/SIREPO_SRDB_ROOT:/SIREPO_SRDB_ROOT:ro,z radiasoft/sirepo:beta bash -l -c "mkdir -v -p /sirepo/user/ && cp -Rv /SIREPO_SRDB_ROOT/* /sirepo/user/ && sirepo service http")
+        container_id=$(docker run -d -t --init --rm --name sirepo -e SIREPO_AUTH_METHODS=bluesky:guest -e SIREPO_AUTH_BLUESKY_SECRET=bluesky -e SIREPO_SRDB_ROOT=/sirepo -e SIREPO_COOKIE_IS_SECURE=false -p 8000:8000 -v $PWD/sirepo_bluesky/tests/SIREPO_SRDB_ROOT:/SIREPO_SRDB_ROOT:ro,z radiasoft/sirepo:beta bash -l -c "mkdir -v -p /sirepo/user/ && cp -Rv /SIREPO_SRDB_ROOT/* /sirepo/user/ && sirepo service http")
         coverage run -m pytest -vvvv -m "docker"  # Run the tests and check for test coverage.
         docker logs $container_id
     else

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Prepare Bluesky and trigger a simulated Sirepo detector
    %run -i examples/prepare_det_env.py
    import sirepo_bluesky.sirepo_detector as sd
    import bluesky.plans as bp
-   sirepo_det = sd.SirepoDetector(sim_id='<sim_id>', reg=db.reg)
+   sirepo_det = sd.SirepoDetector(sim_id='<sim_id>')
    sirepo_det.select_optic('Aperture')
    param1 = sirepo_det.create_parameter('horizontalSize')
    param2 = sirepo_det.create_parameter('verticalSize')

--- a/sirepo_bluesky/sirepo_detector.py
+++ b/sirepo_bluesky/sirepo_detector.py
@@ -27,8 +27,6 @@ class ExternalFileReference(Signal):
             dict(
                 external="FILESTORE:",
                 dtype="array",
-                #shape=self.shape,
-                #dims=("x", "y"),
             )
         )
         return resource_document_data

--- a/sirepo_bluesky/sirepo_detector.py
+++ b/sirepo_bluesky/sirepo_detector.py
@@ -9,7 +9,7 @@ from event_model import compose_resource
 from ophyd import Device, Signal, Component as Cpt
 from ophyd.sim import SynAxis, NullStatus, new_uid
 
-from .srw_handler import read_srw_file, SRWFileHandler
+from .srw_handler import read_srw_file
 from .sirepo_bluesky import SirepoBluesky
 
 

--- a/sirepo_bluesky/sirepo_detector.py
+++ b/sirepo_bluesky/sirepo_detector.py
@@ -45,7 +45,6 @@ class SirepoDetector(Device):
     ----------
     name : str
         The name of the detector
-    reg : Databroker registry
     sim_id : str
         The simulation id corresponding to the Sirepo simulation being run on
         local server
@@ -58,7 +57,6 @@ class SirepoDetector(Device):
 
     """
     image = Cpt(ExternalFileReference, kind="normal")
-    #image = Cpt(Signal)
     shape = Cpt(Signal)
     mean = Cpt(Signal)
     photon_energy = Cpt(Signal)

--- a/sirepo_bluesky/sirepo_detector.py
+++ b/sirepo_bluesky/sirepo_detector.py
@@ -65,10 +65,9 @@ class SirepoDetector(Device):
     horizontal_extent = Cpt(Signal)
     vertical_extent = Cpt(Signal)
 
-    def __init__(self, name='sirepo_det', reg=None, sim_id=None, watch_name=None,
+    def __init__(self, name='sirepo_det', sim_id=None, watch_name=None,
                  sirepo_server='http://10.10.10.10:8000', source_simulation=False, **kwargs):
         super().__init__(name=name, **kwargs)
-        #self.reg = reg
         self._asset_docs_cache = deque()
         self._resource_document = None
         self._datum_factory = None
@@ -77,7 +76,6 @@ class SirepoDetector(Device):
         self.fields = {}
         self.field_units = {}
         self.parents = {}
-        #self._resource_id = None
         self._result = {}
         self._sim_id = sim_id
         self.watch_name = watch_name
@@ -134,7 +132,7 @@ class SirepoDetector(Device):
         date = datetime.datetime.now()
         file_name = new_uid()
         self._resource_document, self._datum_factory, _ = compose_resource(
-            start={"uid": "needed for compose_resource() but will be discarded"},
+            start={'uid': 'needed for compose_resource() but will be discarded'},
             spec='srw',
             root='/tmp/data',
             resource_path=str(Path(date.strftime('%Y/%m/%d')) / Path('{}.dat'.format(file_name))),
@@ -142,12 +140,10 @@ class SirepoDetector(Device):
             resource_kwargs={'ndim': 0}
         )
         # now discard the start uid, a real one will be added later
-        self._resource_document.pop("run_start")
-        self._asset_docs_cache.append(("resource", self._resource_document))
+        self._resource_document.pop('run_start')
+        self._asset_docs_cache.append(('resource', self._resource_document))
 
-        srw_file = Path(self._resource_document["root"]) / Path(self._resource_document["resource_path"])
-        # srw_file = Path('/tmp/data') / Path(date.strftime('%Y/%m/%d')) / \
-        #     Path('{}.dat'.format(datum_id))
+        srw_file = Path(self._resource_document['root']) / Path(self._resource_document['resource_path'])
 
         if not self.source_simulation:
             if self.sirepo_component is not None:
@@ -192,13 +188,12 @@ class SirepoDetector(Device):
             ndim = 2
         ret = read_srw_file(srw_file, ndim=ndim)
 
-        # ndims has been established, add it to the resource document
+        # ndim has now been established, add it to the resource document
         self._resource_document["resource_kwargs"]["ndim"] = ndim
         datum_document = self._datum_factory(datum_kwargs={})
         self._asset_docs_cache.append(("datum", datum_document))
 
         self.image.put(datum_document["datum_id"])
-
         self.shape.put(ret['shape'])
         self.mean.put(ret['mean'])
         self.photon_energy.put(ret['photon_energy'])

--- a/sirepo_bluesky/tests/test_sirepo_det.py
+++ b/sirepo_bluesky/tests/test_sirepo_det.py
@@ -19,7 +19,7 @@ def _test_sirepo_detector(RE, db, tmpdir, sim_id, server_name):
     root_dir = '/tmp/data'
     _ = make_dir_tree(datetime.datetime.now().year, base_path=root_dir)
 
-    sirepo_det = SirepoDetector(sim_id=sim_id, reg=db.reg, sirepo_server=server_name)
+    sirepo_det = SirepoDetector(sim_id=sim_id, sirepo_server=server_name)
     sirepo_det.select_optic('Aperture')
     sirepo_det.create_parameter('horizontalSize')
     sirepo_det.create_parameter('verticalSize')
@@ -63,7 +63,7 @@ def _test_sirepo_det_grid_scan(RE, db, tmpdir, sim_id, server_name):
     root_dir = '/tmp/data'
     _ = make_dir_tree(datetime.datetime.now().year, base_path=root_dir)
 
-    sirepo_det = SirepoDetector(sim_id=sim_id, reg=db.reg, sirepo_server=server_name)
+    sirepo_det = SirepoDetector(sim_id=sim_id, sirepo_server=server_name)
     sirepo_det.select_optic('Aperture')
     param1 = sirepo_det.create_parameter('horizontalSize')
     param2 = sirepo_det.create_parameter('verticalSize')

--- a/sirepo_bluesky/tests/test_sirepo_flyer.py
+++ b/sirepo_bluesky/tests/test_sirepo_flyer.py
@@ -67,7 +67,7 @@ def _test_sirepo_flyer(RE_no_plot, db, tmpdir, sim_id, server_name):
     for i in range(len(t)):
         db_means.append(t.iloc[i]['sirepo_flyer_mean'])
 
-    assert actual_means == db_means, "fly scan means do not match actual means"
+    assert set(actual_means) == set(db_means), "fly scan means do not match actual means"
 
 
 @vcr.use_cassette(f'{cassette_location}/test_sirepo_flyer.yml')


### PR DESCRIPTION
This PR proposes an update to the original databroker integration in `SirepoDetector`, which is not compatible with the most recent databroker release.

The original calls to `insert_resource(...)` and `insert_datum(...)` are replaced with a standard `collect_asset_docs(...)`. In addition the original `image` Signal is replaced with a new ExternalFileReference.

Closes #7, #17, and #19.