### PR TITLE
TST: add pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    docker: marks tests as requiring Docker to be available/running (deselect with '-m "not docker"')


### PR DESCRIPTION
Reported by @jklynch earlier via DM:
```py
sirepo_bluesky/tests/test_sirepo_det.py:50
  /home/vagrant/nslsii-org-forks/sirepo-bluesky-fork/sirepo_bluesky/tests/test_sirepo_det.py:50: PytestUnknownMarkWarning: Unknown pytest.mark.docker - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.docker
```

Following the instructions from https://docs.pytest.org/en/stable/mark.html to make it compliant.