### PR TITLE
added SirepoBluesky.simulation_list()

### DIFF
--- a/sirepo_bluesky/sirepo_bluesky.py
+++ b/sirepo_bluesky/sirepo_bluesky.py
@@ -125,6 +125,10 @@ class SirepoBluesky(object):
         self._assert_success(response, url)
         return response.content
 
+    def simulation_list(self):
+        """ Returns a list of simulations for the authenticated user. """
+        return self._post_json('simulation-list', dict(simulationType=self.sim_type))
+
     @staticmethod
     def update_grazing_vectors(data_to_update, grazing_vectors_params):
         """Update grazing angle vectors"""


### PR DESCRIPTION
Added an API to access the list of simulations for the authenticated user. Example usage:

```python
from sirepo_bluesky.sirepo_bluesky import SirepoBluesky

sim_id = 'maDwjYWE'
sb = SirepoBluesky('http://localhost:8000')
data, schema = sb.auth('srw', sim_id)

for sim in sb.simulation_list():
    print('\n\t'.join(['{}', 'name: {}', 'folder: {}', 'isExample: {}']).format(
	sim['simulationId'], sim['name'], sim['folder'], sim['isExample'],
    ))
```