### PR TITLE
MNT: suggesting a list of code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AbbyGi @jennmald @jklynch @mrakitin


### PR DESCRIPTION
I am proposing to have a list of people in the `CODEOWNERS` file (see the [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for details). This way the whole team will be requested a review. Let me know if it's OK with you. Thanks!