### PR TITLE
Reverted temporarily to intake-0.6.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bluesky
 databroker
 inflection
+intake<=0.6.4
 ipython
 matplotlib
 numconv


### PR DESCRIPTION
This is a temporary fix of sirepo-bluesky tests failing with intake-0.6.5