### PR TITLE
Apply `.set()` to `grazingAngle` component, not device

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,13 +50,15 @@ jobs:
           auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge
 
       - name: Install documentation-building requirements
         run: |
           set -vxeo pipefail
           sudo apt-get update && sudo apt-get install pandoc
           conda env list
-          conda install -c conda-forge shadow3 srwpy
+          mamba install -c conda-forge shadow3 srwpy
           pip install --upgrade pip wheel
           pip install -v .
           pip install -r requirements-dev.txt

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -54,13 +54,15 @@ jobs:
           auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge
 
       - name: Install documentation-building requirements
         run: |
           set -vxeo pipefail
           sudo apt-get update && sudo apt-get install pandoc
           conda env list
-          conda install -c conda-forge shadow3 srwpy
+          mamba install -c conda-forge shadow3 srwpy
           pip install --upgrade pip wheel
           pip install -v .
           pip install -r requirements-dev.txt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,6 +64,8 @@ jobs:
           auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge
 
       - name: Install the package and its dependencies
         run: |
@@ -74,7 +76,7 @@ jobs:
           # line 1: GSETTINGS_SCHEMA_DIR_CONDA_BACKUP: unbound variable
           set -vxeo pipefail
           conda env list
-          conda install -c conda-forge shadow3 srwpy
+          mamba install -c conda-forge shadow3 srwpy
           pip install --upgrade pip wheel
           pip install -v .
           pip install -r requirements-dev.txt

--- a/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
+++ b/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import pprint
@@ -57,14 +58,23 @@ def test_grazing_angle_calculation(srw_tes_simulation):
     )
     globals().update(**objects)
 
+    params_before = copy.deepcopy(toroid.grazingAngle._sirepo_dict)  # noqa F821
+    params_before.pop("grazingAngle")
+
     toroid.grazingAngle.set(10)  # noqa F821
+
+    params_after = copy.deepcopy(toroid.grazingAngle._sirepo_dict)  # noqa F821
+    params_after.pop("grazingAngle")
+
+    params_diff = list(dictdiffer.diff(params_before, params_after))
+    assert len(params_diff) > 0  # should not be empty
 
     expected_vector_values = {
         "nvx": 0,
-        "nvy": 0.9999755001000415,
-        "nvz": -0.006999942833473391,
+        "nvy": 0.9999500004166653,
+        "nvz": -0.009999833334166664,
         "tvx": 0,
-        "tvy": 0.006999942833473391,
+        "tvy": 0.009999833334166664,
     }
 
     actual_vector_values = {

--- a/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
+++ b/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
@@ -52,7 +52,8 @@ def test_beamline_elements_set_put(srw_tes_simulation, method):
         assert abs(new_value - (old_value + 100)) < 1e-8
 
 
-def test_grazing_angle_calculation(srw_tes_simulation):
+@pytest.mark.parametrize("method", ["set", "put"])
+def test_grazing_angle_calculation(srw_tes_simulation, method):
     classes, objects = create_classes(
         srw_tes_simulation.data, connection=srw_tes_simulation
     )
@@ -61,7 +62,7 @@ def test_grazing_angle_calculation(srw_tes_simulation):
     params_before = copy.deepcopy(toroid.grazingAngle._sirepo_dict)  # noqa F821
     params_before.pop("grazingAngle")
 
-    toroid.grazingAngle.set(10)  # noqa F821
+    getattr(toroid.grazingAngle, method)(10)  # noqa F821
 
     params_after = copy.deepcopy(toroid.grazingAngle._sirepo_dict)  # noqa F821
     params_after.pop("grazingAngle")


### PR DESCRIPTION
This update computes the normal and tangential vector components on setting/putting to the `grazingAngle` component of the special mirrors, not the entire device.

The PR also updates the expected values of the components for 10 mrad per Sirepo response:
<img width="245" alt="image" src="https://user-images.githubusercontent.com/13209176/157747090-298017fa-7385-451e-a201-a329f3ba2436.png">

Closes #72.