### PR TITLE
Add systemd service unit for RHEL8

### DIFF
--- a/service/etc/systemd/system/sirepo.service
+++ b/service/etc/systemd/system/sirepo.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Sirepo
+Wants=mongod.service
+After=syslog.target network.target mongod.service
+
+[Service]
+User=root
+Group=root
+SyslogIdentifier=sirepo
+TimeoutStartSec=0
+# Restart=always
+WorkingDirectory=/repos/sirepo-bluesky
+ExecStart=bash /repos/sirepo-bluesky/scripts/start_sirepo.sh -it
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
To be installed into `/etc/systemd/system/sirepo.service` on the target RHEL8 machine.