### PR TITLE
Add env-vars to enable mounting of SIREPO_SRDB_ROOT dir on the host machine

### DIFF
--- a/scripts/start_sirepo.sh
+++ b/scripts/start_sirepo.sh
@@ -15,6 +15,9 @@ elif [ "${arg}" != "-it" -a "${arg}" != "-d" ]; then
     exit 2
 fi
 
+SIREPO_SRDB_HOST="${SIREPO_SRDB_HOST:-}"
+SIREPO_SRDB_GUEST="${SIREPO_SRDB_GUEST:-}"
+
 unset cmd _cmd docker_image SIREPO_DOCKER_CONTAINER_ID
 
 month=$(date +"%m")

--- a/scripts/start_sirepo.sh
+++ b/scripts/start_sirepo.sh
@@ -38,14 +38,22 @@ ${docker_binary} pull ${docker_image}
 ${docker_binary} images
 
 in_docker_cmd="mkdir -v -p /sirepo/ && cp -Rv /SIREPO_SRDB_ROOT/* /sirepo/ && sirepo service http"
-cmd="${docker_binary} run ${arg} --init --rm --name sirepo \
+cmd_start="${docker_binary} run ${arg} --init --rm --name sirepo \
        -e SIREPO_AUTH_METHODS=bluesky:guest \
        -e SIREPO_AUTH_BLUESKY_SECRET=bluesky \
        -e SIREPO_SRDB_ROOT=/sirepo \
        -e SIREPO_COOKIE_IS_SECURE=false \
        -p 8000:8000 \
-       -v $PWD/sirepo_bluesky/tests/SIREPO_SRDB_ROOT:/SIREPO_SRDB_ROOT:ro,z \
-       ${docker_image} bash -l -c \"${in_docker_cmd}\""
+       -v $PWD/sirepo_bluesky/tests/SIREPO_SRDB_ROOT:/SIREPO_SRDB_ROOT:ro,z "
+
+cmd_extra=""
+if [ ! -z "${SIREPO_SRDB_HOST}" -a ! -z "${SIREPO_SRDB_GUEST}" ]; then
+    cmd_extra="-v ${SIREPO_SRDB_HOST}:${SIREPO_SRDB_GUEST} "
+fi
+
+cmd_end="${docker_image} bash -l -c \"${in_docker_cmd}\""
+
+cmd="${cmd_start}${cmd_extra}${cmd_end}"
 
 echo -e "Command to run:\n\n${cmd}\n"
 if [ "${arg}" == "-d" ]; then

--- a/service/etc/systemd/system/sirepo.service
+++ b/service/etc/systemd/system/sirepo.service
@@ -10,6 +10,8 @@ SyslogIdentifier=sirepo
 TimeoutStartSec=0
 # Restart=always
 WorkingDirectory=/repos/sirepo-bluesky
+Environment=SIREPO_SRDB_HOST=/sirepo
+Environment=SIREPO_SRDB_GUEST=/sirepo
 ExecStart=bash /repos/sirepo-bluesky/scripts/start_sirepo.sh -it
 
 [Install]


### PR DESCRIPTION
This should help with overfilled `/sirepo/` dir in the container.