### PR TITLE
DOC: use cloud theme for Sphinx

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,9 @@ jobs:
           export DOCKER_BINARY="docker"
           echo "DOCKER_BINARY=${DOCKER_BINARY}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.6.0
@@ -82,3 +84,8 @@ jobs:
           if [ $status -gt 0 ]; then
               exit $status
           fi
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.REPOSITORY_NAME }}-docs
+          path: docs/build/html/

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -14,7 +14,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v2
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,7 +28,9 @@ jobs:
           export DOCKER_BINARY="docker"
           echo "DOCKER_BINARY=${DOCKER_BINARY}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.6.0
@@ -86,6 +88,11 @@ jobs:
           if [ $status -gt 0 ]; then
               exit $status
           fi
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.REPOSITORY_NAME }}-docs
+          path: docs/build/html/
 
       - name: Deploy documentation to nsls-ii.github.io
         # We pin to the SHA, not the tag, for security reasons.

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
           echo "DOCKER_BINARY=${DOCKER_BINARY}" >> $GITHUB_ENV
 
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.6.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import cloud_sptheme as sptheme
 
 # -- General configuration ------------------------------------------------
 
@@ -107,8 +108,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 html_theme = 'cloud'
-import cloud_sptheme
-html_theme_path = [cloud_sptheme.get_theme_dir()]
+html_theme_path = [sptheme.get_theme_dir()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,9 +106,9 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
-import sphinx_rtd_theme
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = 'cloud'
+import cloud_sptheme
+html_theme_path = [cloud_sptheme.get_theme_dir()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -128,7 +128,7 @@ html_static_path = ['_static']
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
     '**': [
-        'relations.html',  # needs 'show_related': True theme option to display
+        'globaltoc.html',
         'searchbox.html',
     ]
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,5 +15,6 @@ numpydoc
 pandoc
 sphinx
 sphinx-copybutton
-sphinx_rtd_theme
+# sphinx_rtd_theme
+cloud-sptheme
 tabulate


### PR DESCRIPTION
This PR switches the docs theme to https://cloud-sptheme.readthedocs.io (inspired by https://psicode.org/psi4manual/master/). The new theme provides a bit more compact layout/text, and feels more modern.

### Before
![Screenshot 2022-09-15 at 03-55-44 sirepo-bluesky Documentation — sirepo-bluesky 0 post1 gf685ea9 documentation](https://user-images.githubusercontent.com/13209176/190349524-9603147d-938f-4634-ada2-ba4bf9400119.png)

### After
![Screenshot 2022-09-15 at 03-58-18 sirepo-bluesky Documentation — sirepo-bluesky 0 4 3 post41 dev0 g05be2df documentation](https://user-images.githubusercontent.com/13209176/190349530-07887298-2302-41f7-8ff5-ad51bb24c614.png)

Closes https://github.com/NSLS-II/sirepo-bluesky/issues/58.