### PR TITLE
Remove `intake` from the code base

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,6 +74,12 @@ jobs:
           pip list
           conda list
 
+      - name: Copy databroker config file
+        run: |
+          set -vxeuo pipefail
+          mkdir -v -p ~/.config/databroker/
+          cp examples/local.yml ~/.config/databroker/
+
       - name: Build Docs
         run: |
           set -vxeuo pipefail

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
 
       - name: Install dev dependencies
         run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -78,6 +78,12 @@ jobs:
           pip list
           conda list
 
+      - name: Copy databroker config file
+        run: |
+          set -vxeuo pipefail
+          mkdir -v -p ~/.config/databroker/
+          cp examples/local.yml ~/.config/databroker/
+
       - name: Build Docs
         run: |
           set -vxeuo pipefail

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -90,6 +90,12 @@ jobs:
           pip list
           conda list
 
+      - name: Copy databroker config file
+        run: |
+          set -vxeuo pipefail
+          mkdir -v -p ~/.config/databroker/
+          cp examples/local.yml ~/.config/databroker/
+
       - name: Test with pytest
         run: |
           set -vxuo pipefail

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/ambv/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,9 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    - id: check-yaml
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
   - repo: https://github.com/ambv/black
     rev: 23.1.0
     hooks:

--- a/docs/build-table.py
+++ b/docs/build-table.py
@@ -15,7 +15,6 @@ def find_predefined_examples(
     tablefmt="rst",
     verbose=False,
 ):
-
     base_url = "https://github.com/NSLS-II/sirepo-bluesky/tree/main/"
 
     pattern_file = f"{pattern}/sirepo-data.json"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,10 @@ area-detector-handlers
 bluesky
 databroker
 inflection
-intake<=0.6.4
 ipython
 matplotlib
 numconv
-numpy<1.24.0
+numpy
 ophyd
 peakutils
 pymongo

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,6 @@ setup(
         "console_scripts": [
             # 'command = some.module:some_function',
         ],
-        # entry point to avoid local.yml file
-        # https://blueskyproject.io/databroker/reference/configuration.html?highlight=entry%20point#advanced-configuration-via-python-package
-        "intake.catalogs": ["local = sirepo_bluesky:sirepo_bluesky_catalog_instance"],
     },
     include_package_data=True,
     package_data={

--- a/sirepo_bluesky/__init__.py
+++ b/sirepo_bluesky/__init__.py
@@ -1,18 +1,9 @@
-import intake
 from ophyd import Signal
 
 from ._version import get_versions
 
 __version__ = get_versions()["version"]
 del get_versions
-
-# Look up a driver class by its name in registry.
-catalog_class = intake.registry["bluesky-mongo-normalized-catalog"]
-
-sirepo_bluesky_catalog_instance = catalog_class(
-    metadatastore_db="mongodb://localhost:27017/md",
-    asset_registry_db="mongodb://localhost:27017/ar",
-)
 
 
 class ExternalFileReference(Signal):

--- a/sirepo_bluesky/sirepo_ophyd.py
+++ b/sirepo_bluesky/sirepo_ophyd.py
@@ -382,7 +382,6 @@ def create_classes(sirepo_data, connection, create_objects=True, extra_model_fie
 
             components = {}
             for k, v in el.items():
-
                 if (
                     "type" in el
                     and el["type"] in ["sphericalMirror", "toroidalMirror", "ellipsoidMirror"]


### PR DESCRIPTION
This PR will help to unblock the latest versions of `sirepo-bluesky` to work with `tiled` (where intake should not be used).