### PR TITLE
DOC: release notes for v0.6.0

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,7 +5,7 @@ Release History
 v0.6.0 (2023-02-23)
 -------------------
 This is a major release dropping support of `intake
-<https://intake.readthedocs.io/en/latest/>` and extending support of MAD-X
+<https://intake.readthedocs.io/en/latest/>`_ and extending support of MAD-X
 simulations.
 
 API

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,47 @@
 Release History
 ===============
 
+v0.6.0 (2023-02-23)
+-------------------
+This is a major release dropping support of `intake
+<https://intake.readthedocs.io/en/latest/>` and extending support of MAD-X
+simulations.
+
+API
+...
+- Added ``SirepoSignalRO``.
+- Removed `intake <https://intake.readthedocs.io/en/latest/>`_ from the code
+  base.
+
+Applications
+............
+- Added support for the MAD-X commands via the API.
+
+Examples
+........
+- Updated MAD-X simulation examples to better reflect ATF Beamline 1 and
+  Beamline 2.
+
+Documentation
+.............
+- Added axes labels to the Beam Statistics Report plots.
+- Fixed minor spelling errors.
+- Updated the documentation with the new MAD-X simulation examples
+  demonstrating the ``betx``/``bety`` vs. ``s`` distribution plots before and
+  after a parameters change, compared to the Sirepo browser-based interface.
+
+Linting/styling
+................
+- Enforced formatting with `black <https://black.readthedocs.io/en/stable/>`_,
+  `flake8 <https://flake8.pycqa.org/en/latest/>`_, and `isort
+  <https://pycqa.github.io/isort/>`_ via `pre-commit hook
+  <https://pre-commit.com/>`_.
+
+CI improvements
+...............
+- Updated the linter CI config to run the ``pre-commit`` checks.
+
+
 v0.5.0 (2022-11-04)
 -------------------
 This is a major release dropping support of Python 3.7 and adding support of


### PR DESCRIPTION
The release notes for the upcoming release based on this range of commits:

https://github.com/NSLS-II/sirepo-bluesky/compare/v0.5.0...b3e4d906f99562595732a8806c265e52fa97df0a.