### PR TITLE
PKG: Update dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ flake8
 isort
 pre-commit
 pytest
-vcrpy
+vcrpy>=4.3.1
 # These are dependencies of various sphinx extensions for documentation.
 # cloud-sptheme
 furo

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pymongo
 pyqt5>=5.9
 requests
 shadow3>=23.1.4
-srwpy>=4.0.0b0
+srwpy>=4.0.0b1
 tfs-pandas
 unyt
-urllib3<2.0.0
+xraylib


### PR DESCRIPTION
- `srwpy` minimum pin 4.0.0b1 to pick up some recent fixes
- `vcrpy` minumum pin 4.3.1 to fix the urllib v1/2 confusion
- add `xraylib` to disable a print about its unavailability while running examples, tests, etc.