### PR TITLE
convert integer sirepo parameters to floats

### DIFF
--- a/sirepo_bluesky/sirepo_ophyd.py
+++ b/sirepo_bluesky/sirepo_ophyd.py
@@ -401,7 +401,7 @@ def create_classes(sirepo_data, connection, create_objects=True, extra_model_fie
 
                 components[k] = Cpt(
                     cpt_class,
-                    value=v,
+                    value=(float(v) if type(v) is int else v),
                     sirepo_dict=sirepo_dict,
                     sirepo_param=k,
                 )


### PR DESCRIPTION
Sirepo reports all the simulation parameters as integers, though most of them should be floats. I changed the ophyd initialization just cast all the integers to floats. Probably this should be dealt with on the sirepo side at some point. 