### PR TITLE
Propagation parameters

### DIFF
--- a/docs/source/notebooks/elements.ipynb
+++ b/docs/source/notebooks/elements.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -12,6 +13,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -21,6 +23,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -41,7 +44,7 @@
     "connection = SirepoBluesky(\"http://localhost:8000\")\n",
     "\n",
     "data, schema = connection.auth(\"srw\", \"00000002\")\n",
-    "classes, objects = create_classes(connection.data, connection=connection)\n",
+    "classes, objects = create_classes(connection=connection)\n",
     "globals().update(**objects)\n",
     "\n",
     "aperture.horizontalSize.kind = \"hinted\"\n",
@@ -83,6 +86,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -105,7 +109,7 @@
     "connection = SirepoBluesky(\"http://localhost:8000\")\n",
     "\n",
     "data, schema = connection.auth(\"shadow\", \"00000002\")\n",
-    "classes, objects = create_classes(connection.data, connection=connection)\n",
+    "classes, objects = create_classes(connection=connection)\n",
     "globals().update(**objects)\n",
     "\n",
     "print(f\"Number of points before change: {data['models']['simulation']['npoint']}\")\n",
@@ -150,6 +154,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -173,7 +178,7 @@
     "\n",
     "data, schema = connection.auth(\"shadow\", \"00000002\")\n",
     "\n",
-    "classes, objects = create_classes(connection.data, connection=connection)\n",
+    "classes, objects = create_classes(connection=connection)\n",
     "globals().update(**objects)\n",
     "\n",
     "bsr = BeamStatisticsReport(name=\"bsr\", connection=connection)\n",

--- a/docs/source/notebooks/madx.ipynb
+++ b/docs/source/notebooks/madx.ipynb
@@ -36,7 +36,6 @@
     "\n",
     "data, schema = connection.auth(\"madx\", \"00000002\")\n",
     "classes, objects = create_classes(\n",
-    "    connection.data,\n",
     "    connection=connection,\n",
     "    extra_model_fields=[\"rpnVariables\", \"commands\"],\n",
     ")\n",

--- a/sirepo_bluesky/sirepo_ophyd.py
+++ b/sirepo_bluesky/sirepo_ophyd.py
@@ -390,10 +390,10 @@ class PropagationConfig(SimplePropagationConfig):
         return propagation_read
 
 
-def create_classes(sirepo_data, connection, create_objects=True, extra_model_fields=[]):
+def create_classes(connection, create_objects=True, extra_model_fields=[]):
     classes = {}
     objects = {}
-    data = copy.deepcopy(sirepo_data)
+    data = copy.deepcopy(connection.data)
 
     sim_type = connection.sim_type
 
@@ -500,11 +500,11 @@ def create_classes(sirepo_data, connection, create_objects=True, extra_model_fie
                     cpt_class = SirepoSignal
 
                 if "type" in el and el["type"] not in ["undulator", "intensityReport"]:
-                    sirepo_dict = sirepo_data["models"][model_field][i]
+                    sirepo_dict = connection.data["models"][model_field][i]
                 elif sim_type == "madx" and model_field in ["rpnVariables", "commands"]:
-                    sirepo_dict = sirepo_data["models"][model_field][i]
+                    sirepo_dict = connection.data["models"][model_field][i]
                 else:
-                    sirepo_dict = sirepo_data["models"][model_field]
+                    sirepo_dict = connection.data["models"][model_field]
 
                 components[k] = Cpt(
                     cpt_class,

--- a/sirepo_bluesky/sirepo_ophyd.py
+++ b/sirepo_bluesky/sirepo_ophyd.py
@@ -537,10 +537,8 @@ def create_classes(connection, create_objects=True, extra_model_fields=[]):
                             sirepo_param=i,
                         )
                     )
-                propagation = PropagationConfig(*sirepo_propagation[:])
-                classes[inflection.camelize(object_name)] = propagation
                 if create_objects:
-                    objects[object_name] = propagation
+                    objects[object_name] = PropagationConfig(*sirepo_propagation[:])
 
         if sim_type == "srw":
             post_prop_params = connection.data["models"]["postPropagation"]
@@ -555,9 +553,8 @@ def create_classes(connection, create_objects=True, extra_model_fields=[]):
                         sirepo_param=i,
                     )
                 )
-            propagation = PropagationConfig(*sirepo_propagation[:])
-            classes[inflection.camelize(object_name)] = propagation
+            classes["propagation_parameters"] = PropagationConfig
             if create_objects:
-                objects[object_name] = propagation
+                objects[object_name] = PropagationConfig(*sirepo_propagation[:])
 
     return classes, objects

--- a/sirepo_bluesky/sirepo_ophyd.py
+++ b/sirepo_bluesky/sirepo_ophyd.py
@@ -379,6 +379,11 @@ def create_classes(sirepo_data, connection, create_objects=True, extra_model_fie
     sim_type = connection.sim_type
 
     SimTypeConfig = namedtuple("SimTypeConfig", "element_location class_name_field")
+    PropagationConfig = namedtuple(
+        "PropagationConfig",
+        "resize_before resize_after precision propagator_type "
+        + "fourier_resize hrange_mod hres_mod vrange_mod vres_mod",
+    )
 
     srw_config = SimTypeConfig("beamline", "title")
     shadow_config = SimTypeConfig("beamline", "title")
@@ -504,5 +509,59 @@ def create_classes(sirepo_data, connection, create_objects=True, extra_model_fie
             classes[object_name] = cls
             if create_objects:
                 objects[object_name] = cls(name=object_name)
+
+            prop_params = connection.data["models"]["propagation"][str(el["id"])][0]
+            sirepo_propagation = []
+            object_name = object_name + "_propagation"
+            for i in range(9):
+                sirepo_propagation.append(
+                    SirepoSignal(
+                        name=f"{object_name} {i+1}",
+                        value=prop_params[i],
+                        sirepo_dict=prop_params,
+                        sirepo_param=i,
+                    )
+                )
+            propagation = PropagationConfig(
+                sirepo_propagation[0],
+                sirepo_propagation[1],
+                sirepo_propagation[2],
+                sirepo_propagation[3],
+                sirepo_propagation[4],
+                sirepo_propagation[5],
+                sirepo_propagation[6],
+                sirepo_propagation[7],
+                sirepo_propagation[8],
+            )
+            classes[object_name] = propagation
+            if create_objects:
+                objects[object_name] = propagation
+
+        post_prop_params = connection.data["models"]["postPropagation"]
+        sirepo_propagation = []
+        object_name = "postPropagation"
+        for i in range(9):
+            sirepo_propagation.append(
+                SirepoSignal(
+                    name=f"{object_name} {i+1}",
+                    value=post_prop_params[i],
+                    sirepo_dict=post_prop_params,
+                    sirepo_param=i,
+                )
+            )
+        propagation = PropagationConfig(
+            sirepo_propagation[0],
+            sirepo_propagation[1],
+            sirepo_propagation[2],
+            sirepo_propagation[3],
+            sirepo_propagation[4],
+            sirepo_propagation[5],
+            sirepo_propagation[6],
+            sirepo_propagation[7],
+            sirepo_propagation[8],
+        )
+        classes[object_name] = propagation
+        if create_objects:
+            objects[object_name] = propagation
 
     return classes, objects

--- a/sirepo_bluesky/sirepo_ophyd.py
+++ b/sirepo_bluesky/sirepo_ophyd.py
@@ -538,14 +538,14 @@ def create_classes(connection, create_objects=True, extra_model_fields=[]):
                         )
                     )
                 propagation = PropagationConfig(*sirepo_propagation[:])
-                classes[object_name] = propagation
+                classes[inflection.camelize(object_name)] = propagation
                 if create_objects:
                     objects[object_name] = propagation
 
         if sim_type == "srw":
             post_prop_params = connection.data["models"]["postPropagation"]
             sirepo_propagation = []
-            object_name = "postPropagation"
+            object_name = "post_propagation"
             for i in range(9):
                 sirepo_propagation.append(
                     SirepoSignal(
@@ -556,7 +556,7 @@ def create_classes(connection, create_objects=True, extra_model_fields=[]):
                     )
                 )
             propagation = PropagationConfig(*sirepo_propagation[:])
-            classes[object_name] = propagation
+            classes[inflection.camelize(object_name)] = propagation
             if create_objects:
                 objects[object_name] = propagation
 

--- a/sirepo_bluesky/sirepo_ophyd.py
+++ b/sirepo_bluesky/sirepo_ophyd.py
@@ -510,15 +510,44 @@ def create_classes(sirepo_data, connection, create_objects=True, extra_model_fie
             if create_objects:
                 objects[object_name] = cls(name=object_name)
 
-            prop_params = connection.data["models"]["propagation"][str(el["id"])][0]
+            if sim_type == "srw":
+                prop_params = connection.data["models"]["propagation"][str(el["id"])][0]
+                sirepo_propagation = []
+                object_name = object_name + "_propagation"
+                for i in range(9):
+                    sirepo_propagation.append(
+                        SirepoSignal(
+                            name=f"{object_name} {i+1}",
+                            value=prop_params[i],
+                            sirepo_dict=prop_params,
+                            sirepo_param=i,
+                        )
+                    )
+                propagation = PropagationConfig(
+                    sirepo_propagation[0],
+                    sirepo_propagation[1],
+                    sirepo_propagation[2],
+                    sirepo_propagation[3],
+                    sirepo_propagation[4],
+                    sirepo_propagation[5],
+                    sirepo_propagation[6],
+                    sirepo_propagation[7],
+                    sirepo_propagation[8],
+                )
+                classes[object_name] = propagation
+                if create_objects:
+                    objects[object_name] = propagation
+
+        if sim_type == "srw":
+            post_prop_params = connection.data["models"]["postPropagation"]
             sirepo_propagation = []
-            object_name = object_name + "_propagation"
+            object_name = "postPropagation"
             for i in range(9):
                 sirepo_propagation.append(
                     SirepoSignal(
                         name=f"{object_name} {i+1}",
-                        value=prop_params[i],
-                        sirepo_dict=prop_params,
+                        value=post_prop_params[i],
+                        sirepo_dict=post_prop_params,
                         sirepo_param=i,
                     )
                 )
@@ -536,32 +565,5 @@ def create_classes(sirepo_data, connection, create_objects=True, extra_model_fie
             classes[object_name] = propagation
             if create_objects:
                 objects[object_name] = propagation
-
-        post_prop_params = connection.data["models"]["postPropagation"]
-        sirepo_propagation = []
-        object_name = "postPropagation"
-        for i in range(9):
-            sirepo_propagation.append(
-                SirepoSignal(
-                    name=f"{object_name} {i+1}",
-                    value=post_prop_params[i],
-                    sirepo_dict=post_prop_params,
-                    sirepo_param=i,
-                )
-            )
-        propagation = PropagationConfig(
-            sirepo_propagation[0],
-            sirepo_propagation[1],
-            sirepo_propagation[2],
-            sirepo_propagation[3],
-            sirepo_propagation[4],
-            sirepo_propagation[5],
-            sirepo_propagation[6],
-            sirepo_propagation[7],
-            sirepo_propagation[8],
-        )
-        classes[object_name] = propagation
-        if create_objects:
-            objects[object_name] = propagation
 
     return classes, objects

--- a/sirepo_bluesky/sirepo_ophyd.py
+++ b/sirepo_bluesky/sirepo_ophyd.py
@@ -527,27 +527,17 @@ def create_classes(connection, create_objects=True, extra_model_fields=[]):
             if sim_type == "srw" and model_field == "beamline":
                 prop_params = connection.data["models"]["propagation"][str(el["id"])][0]
                 sirepo_propagation = []
-                object_name = object_name + "_propagation"
+                object_name += "_propagation"
                 for i in range(9):
                     sirepo_propagation.append(
                         SirepoSignal(
-                            name=f"{object_name} {i+1}",
-                            value=prop_params[i],
+                            name=f"{object_name}_{SimplePropagationConfig._fields[i]}",
+                            value=float(prop_params[i]),
                             sirepo_dict=prop_params,
                             sirepo_param=i,
                         )
                     )
-                propagation = PropagationConfig(
-                    sirepo_propagation[0],
-                    sirepo_propagation[1],
-                    sirepo_propagation[2],
-                    sirepo_propagation[3],
-                    sirepo_propagation[4],
-                    sirepo_propagation[5],
-                    sirepo_propagation[6],
-                    sirepo_propagation[7],
-                    sirepo_propagation[8],
-                )
+                propagation = PropagationConfig(*sirepo_propagation[:])
                 classes[object_name] = propagation
                 if create_objects:
                     objects[object_name] = propagation
@@ -560,22 +550,12 @@ def create_classes(connection, create_objects=True, extra_model_fields=[]):
                 sirepo_propagation.append(
                     SirepoSignal(
                         name=f"{object_name}_{SimplePropagationConfig._fields[i]}",
-                        value=post_prop_params[i],
+                        value=float(post_prop_params[i]),
                         sirepo_dict=post_prop_params,
                         sirepo_param=i,
                     )
                 )
-            propagation = PropagationConfig(
-                sirepo_propagation[0],
-                sirepo_propagation[1],
-                sirepo_propagation[2],
-                sirepo_propagation[3],
-                sirepo_propagation[4],
-                sirepo_propagation[5],
-                sirepo_propagation[6],
-                sirepo_propagation[7],
-                sirepo_propagation[8],
-            )
+            propagation = PropagationConfig(*sirepo_propagation[:])
             classes[object_name] = propagation
             if create_objects:
                 objects[object_name] = propagation

--- a/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
+++ b/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
@@ -17,7 +17,7 @@ from sirepo_bluesky.sirepo_ophyd import BeamStatisticsReport, create_classes
 
 
 def test_beamline_elements_as_ophyd_objects(srw_tes_simulation):
-    classes, objects = create_classes(srw_tes_simulation.data, connection=srw_tes_simulation)
+    classes, objects = create_classes(connection=srw_tes_simulation)
 
     for name, obj in objects.items():
         pprint.pprint(obj.read())
@@ -29,7 +29,7 @@ def test_beamline_elements_as_ophyd_objects(srw_tes_simulation):
 
 
 def test_empty_simulation(srw_empty_simulation):
-    classes, objects = create_classes(srw_empty_simulation.data, connection=srw_empty_simulation)
+    classes, objects = create_classes(connection=srw_empty_simulation)
     globals().update(**objects)
 
     assert not srw_empty_simulation.data["models"]["beamline"]
@@ -39,7 +39,7 @@ def test_empty_simulation(srw_empty_simulation):
 
 @pytest.mark.parametrize("method", ["set", "put"])
 def test_beamline_elements_set_put(srw_tes_simulation, method):
-    classes, objects = create_classes(srw_tes_simulation.data, connection=srw_tes_simulation)
+    classes, objects = create_classes(connection=srw_tes_simulation)
     globals().update(**objects)
 
     i = 0
@@ -66,7 +66,7 @@ def test_beamline_elements_set_put(srw_tes_simulation, method):
 
 @pytest.mark.parametrize("method", ["set", "put"])
 def test_crl_calculation(srw_chx_simulation, method):
-    classes, objects = create_classes(srw_chx_simulation.data, connection=srw_chx_simulation)
+    classes, objects = create_classes(connection=srw_chx_simulation)
     globals().update(**objects)
 
     params_before = copy.deepcopy(crl1.tipRadius._sirepo_dict)  # noqa F821
@@ -95,7 +95,7 @@ def test_crl_calculation(srw_chx_simulation, method):
 
 @pytest.mark.parametrize("method", ["set", "put"])
 def test_crystal_calculation(srw_tes_simulation, method):
-    classes, objects = create_classes(srw_tes_simulation.data, connection=srw_tes_simulation)
+    classes, objects = create_classes(connection=srw_tes_simulation)
     globals().update(**objects)
 
     params_before = copy.deepcopy(mono_crystal1.energy._sirepo_dict)  # noqa F821
@@ -156,7 +156,7 @@ def test_crystal_calculation(srw_tes_simulation, method):
 
 @pytest.mark.parametrize("method", ["set", "put"])
 def test_grazing_angle_calculation(srw_tes_simulation, method):
-    classes, objects = create_classes(srw_tes_simulation.data, connection=srw_tes_simulation)
+    classes, objects = create_classes(connection=srw_tes_simulation)
     globals().update(**objects)
 
     params_before = copy.deepcopy(toroid.grazingAngle._sirepo_dict)  # noqa F821
@@ -190,7 +190,7 @@ def test_grazing_angle_calculation(srw_tes_simulation, method):
 
 
 def test_beamline_elements_simple_connection(srw_basic_simulation):
-    classes, objects = create_classes(srw_basic_simulation.data, connection=srw_basic_simulation)
+    classes, objects = create_classes(connection=srw_basic_simulation)
 
     for name, obj in objects.items():
         pprint.pprint(obj.read())
@@ -203,7 +203,6 @@ def test_beamline_elements_simple_connection(srw_basic_simulation):
 
 def test_srw_source_with_run_engine(RE, db, srw_ari_simulation, num_steps=5):
     classes, objects = create_classes(
-        srw_ari_simulation.data,
         connection=srw_ari_simulation,
         extra_model_fields=["undulator", "intensityReport"],
     )
@@ -259,7 +258,7 @@ def test_srw_source_with_run_engine(RE, db, srw_ari_simulation, num_steps=5):
 
 
 def test_srw_propagation_with_run_engine(RE, db, srw_chx_simulation, num_steps=5):
-    classes, objects = create_classes(srw_chx_simulation.data, connection=srw_chx_simulation)
+    classes, objects = create_classes(connection=srw_chx_simulation)
     globals().update(**objects)
 
     postPropagation.hrange_mod.kind = "hinted"  # noqa F821
@@ -284,7 +283,7 @@ def test_srw_propagation_with_run_engine(RE, db, srw_chx_simulation, num_steps=5
 
 
 def test_shadow_with_run_engine(RE, db, shadow_tes_simulation, num_steps=5):
-    classes, objects = create_classes(shadow_tes_simulation.data, connection=shadow_tes_simulation)
+    classes, objects = create_classes(connection=shadow_tes_simulation)
     globals().update(**objects)
 
     aperture.horizontalSize.kind = "hinted"  # noqa F821
@@ -329,7 +328,7 @@ def test_shadow_with_run_engine(RE, db, shadow_tes_simulation, num_steps=5):
 
 
 def test_beam_statistics_report_only(RE, db, shadow_tes_simulation):
-    classes, objects = create_classes(shadow_tes_simulation.data, connection=shadow_tes_simulation)
+    classes, objects = create_classes(connection=shadow_tes_simulation)
     globals().update(**objects)
 
     bsr = BeamStatisticsReport(name="bsr", connection=shadow_tes_simulation)
@@ -369,7 +368,7 @@ def test_beam_statistics_report_only(RE, db, shadow_tes_simulation):
 
 
 def test_beam_statistics_report_and_watchpoint(RE, db, shadow_tes_simulation):
-    classes, objects = create_classes(shadow_tes_simulation.data, connection=shadow_tes_simulation)
+    classes, objects = create_classes(connection=shadow_tes_simulation)
     globals().update(**objects)
 
     bsr = BeamStatisticsReport(name="bsr", connection=shadow_tes_simulation)
@@ -404,7 +403,7 @@ def test_beam_statistics_report_and_watchpoint(RE, db, shadow_tes_simulation):
 def test_mad_x_elements_set_put(madx_resr_storage_ring_simulation, method):
     connection = madx_resr_storage_ring_simulation
     data = connection.data
-    classes, objects = create_classes(data, connection=connection)
+    classes, objects = create_classes(connection=connection)
     globals().update(**objects)
 
     for i, (k, v) in enumerate(objects.items()):
@@ -426,8 +425,7 @@ def test_mad_x_elements_set_put(madx_resr_storage_ring_simulation, method):
 
 def test_mad_x_elements_simple_connection(madx_bl2_triplet_tdc_simulation):
     connection = madx_bl2_triplet_tdc_simulation
-    data = connection.data
-    classes, objects = create_classes(data, connection=connection)
+    classes, objects = create_classes(connection=connection)
     for name, obj in objects.items():
         pprint.pprint(obj.read())
 
@@ -439,8 +437,7 @@ def test_mad_x_elements_simple_connection(madx_bl2_triplet_tdc_simulation):
 
 def test_madx_with_run_engine(RE, db, madx_bl2_triplet_tdc_simulation):
     connection = madx_bl2_triplet_tdc_simulation
-    data = connection.data
-    classes, objects = create_classes(data, connection=connection)
+    classes, objects = create_classes(connection=connection)
     globals().update(**objects)
 
     madx_flyer = MADXFlyer(
@@ -477,7 +474,6 @@ def test_madx_variables_with_run_engine(RE, db, madx_bl2_triplet_tdc_simulation)
     connection = madx_bl2_triplet_tdc_simulation
     data = connection.data
     classes, objects = create_classes(
-        data,
         connection=connection,
         extra_model_fields=["rpnVariables"],
     )
@@ -512,7 +508,6 @@ def test_madx_commands_with_run_engine(RE, db, madx_bl2_triplet_tdc_simulation):
     connection = madx_bl2_triplet_tdc_simulation
     data = connection.data
     classes, objects = create_classes(
-        data,
         connection=connection,
         extra_model_fields=["commands"],
     )
@@ -548,7 +543,6 @@ def test_madx_variables_and_commands_with_run_engine(RE, db, madx_bl2_triplet_td
     connection = madx_bl2_triplet_tdc_simulation
     data = connection.data
     classes, objects = create_classes(
-        data,
         connection=connection,
         extra_model_fields=["rpnVariables", "commands"],
     )

--- a/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
+++ b/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
@@ -33,7 +33,7 @@ def test_empty_simulation(srw_empty_simulation):
     globals().update(**objects)
 
     assert not srw_empty_simulation.data["models"]["beamline"]
-    objects.pop("postPropagation")
+    objects.pop("post_propagation")
     assert not objects
 
 
@@ -261,9 +261,9 @@ def test_srw_propagation_with_run_engine(RE, db, srw_chx_simulation, num_steps=5
     classes, objects = create_classes(connection=srw_chx_simulation)
     globals().update(**objects)
 
-    postPropagation.hrange_mod.kind = "hinted"  # noqa F821
+    post_propagation.hrange_mod.kind = "hinted"  # noqa F821
 
-    (uid,) = RE(bp.scan([sample], postPropagation.hrange_mod, 0.1, 0.3, num_steps))  # noqa F821
+    (uid,) = RE(bp.scan([sample], post_propagation.hrange_mod, 0.1, 0.3, num_steps))  # noqa F821
     hdr = db[uid]
     tbl = hdr.table(fill=True)
     print(tbl)

--- a/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
+++ b/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
@@ -43,7 +43,7 @@ def test_beamline_elements_set_put(srw_tes_simulation, method):
     globals().update(**objects)
 
     i = 0
-    for j, (k, v) in enumerate(objects.items()):
+    for k, v in objects.items():
         if "element_position" in v.component_names:
             old_value = v.element_position.get()
             old_sirepo_value = srw_tes_simulation.data["models"]["beamline"][i]["position"]
@@ -277,7 +277,7 @@ def test_srw_propagation_with_run_engine(RE, db, srw_chx_simulation, num_steps=5
         sample_image.append(np.array(list(hdr.data("sample_image"))[i]))
 
     # Check the shape of the image data is right and that hrange_mod was properly changed:
-    for i, hrange_mod in zip(range(num_steps), np.linspace(0.1, 0.3, num_steps)):
+    for i, hrange_mod in enumerate(np.linspace(0.1, 0.3, num_steps)):
         assert json.loads(tbl["sample_sirepo_data_json"][i + 1])["models"]["postPropagation"][5] == hrange_mod
         assert sample_image[i].shape == (294, int(hrange_mod * 1760))
 

--- a/sirepo_bluesky/tests/test_stateless_compute.py
+++ b/sirepo_bluesky/tests/test_stateless_compute.py
@@ -68,7 +68,7 @@ def test_stateless_compute_crl_characteristics_basic(srw_chx_simulation, RE):
     assert diff, "The browser request and expected response match, but are expected to be different."
     pprint.pprint(diff)
 
-    classes, objects = create_classes(srw_chx_simulation.data, connection=srw_chx_simulation)
+    classes, objects = create_classes(connection=srw_chx_simulation)
 
     crl1 = objects["crl1"]
 
@@ -86,7 +86,7 @@ def test_stateless_compute_crl_characteristics_basic(srw_chx_simulation, RE):
 
 
 def test_stateless_compute_crystal_orientation_basic(srw_tes_simulation, RE):
-    classes, objects = create_classes(srw_tes_simulation.data, connection=srw_tes_simulation)
+    classes, objects = create_classes(connection=srw_tes_simulation)
     globals().update(**objects)
     mc1 = mono_crystal1  # noqa
 
@@ -184,7 +184,7 @@ def test_stateless_compute_crystal_orientation_basic(srw_tes_simulation, RE):
 
 @vcr.use_cassette(f"{cassette_location}/test_crl_characteristics.yml")
 def test_stateless_compute_crl_characteristics_advanced(srw_chx_simulation, tmp_path):
-    classes, objects = create_classes(srw_chx_simulation.data, connection=srw_chx_simulation)
+    classes, objects = create_classes(connection=srw_chx_simulation)
 
     _generate_test_crl_file(tmp_path / "test_crl_characteristics.json", objects["crl1"], srw_chx_simulation)
 
@@ -202,7 +202,7 @@ def test_stateless_compute_crl_characteristics_advanced(srw_chx_simulation, tmp_
 
 @vcr.use_cassette(f"{cassette_location}/test_crystal_characteristics.yml")
 def test_stateless_compute_crystal_advanced(srw_tes_simulation, tmp_path):
-    classes, objects = create_classes(srw_tes_simulation.data, connection=srw_tes_simulation)
+    classes, objects = create_classes(connection=srw_tes_simulation)
 
     _generate_test_crystal_file(
         tmp_path / "test_compute_crystal.json", objects["mono_crystal1"], srw_tes_simulation
@@ -226,7 +226,7 @@ def test_stateless_compute_crystal_advanced(srw_tes_simulation, tmp_path):
 
 
 def test_stateless_compute_with_RE(RE, srw_chx_simulation, db):
-    classes, objects = create_classes(srw_chx_simulation.data, connection=srw_chx_simulation)
+    classes, objects = create_classes(connection=srw_chx_simulation)
     globals().update(**objects)
     crl1.tipRadius.kind = "hinted"  # noqa
     sample.duration.kind = "hinted"  # noqa


### PR DESCRIPTION
- Added propagation parameters as ophyd objects. Examples of these can be found at https://github.com/radiasoft/sirepo/wiki/SRW-Propagation-Parameters
- Removed the sirepo_data parameter from create_classes as it was redundant.