### PR TITLE
DOC: release notes for v0.7.1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
       fail-fast: false
 
     defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         language_version: python3.10
@@ -17,7 +17,7 @@ repos:
         exclude: ^(.*\.py)
         args: [--line-length=88]
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,6 +5,8 @@ Release History
 v0.7.1 (2023-08-18)
 -------------------
 
+This is a maintenance release with small API, tests, CI, and documentation updates.
+
 API
 ...
 
@@ -14,10 +16,6 @@ API
   imported in IPython and Jupyter notebooks (both interactively and in the docs).
   The argparser CLI args parser was added to the module so that users can
   specify the databroker config name and root path for the data files.
-
-Maintenance
-...........
-
 
 Documentation
 .............

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -14,7 +14,7 @@ API
 - Moved and updated the ``prepare_*_env.py`` code from the ``examples/``
   directory of the repository to the library code, so that the new module can be
   imported in IPython and Jupyter notebooks (both interactively and in the docs).
-  The argparser CLI args parser was added to the module so that users can
+  The ``argparser`` CLI argument parser was added to the module so that users can
   specify the databroker config name and root path for the data files.
 
 Documentation

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -20,8 +20,8 @@ API
 Documentation
 .............
 
-- Pinned Sphinx to version 7.2.2+ to make it more compatible with the ``furo``
-  theme.
+- Pinned ``furo`` minimum version to 2023.8.17 to compatiblity with Sphinx 7.2.0
+  and 7.2.1.
 
 Tests
 .....

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,8 +2,52 @@
 Release History
 ===============
 
+v0.7.1 (2023-08-18)
+-------------------
+
+API
+...
+
+- Enabled generation beamline elements from existing simulations.
+- Moved and updated the ``prepare_*_env.py`` code from the ``examples/``
+  directory of the repository to the library code, so that the new module can be
+  imported in IPython and Jupyter notebooks (both interactively and in the docs).
+  The argparser CLI args parser was added to the module so that users can
+  specify the databroker config name and root path for the data files.
+
+Maintenance
+...........
+
+
+Documentation
+.............
+
+- Pinned Sphinx to version 7.2.2+ to make it more compatible with the ``furo``
+  theme.
+
+Tests
+.....
+
+- Sorted out test failures happening due to a small numerical difference of the
+  results from the PyPI-installed ``srwpy`` in the Sirepo Docker.
+- Removed an old/irrelevant test.
+
+CI improvements
+...............
+
+- Switched from the conda action to built-in Python for CI (saves >2 minutes per
+  run).
+
+
 v0.7.0 (2023-08-04)
 -------------------
+
+This is a major release with new features to support the ``stateless-compute``
+API and propagation parameters in Sirepo/SRW and the old API used prior to
+v0.4.0 removed.
+
+This release includes many useful contributions from the SULI 2023 summer intern
+Riley Bode. Thank you!
 
 New features
 ............

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -27,7 +27,7 @@ Tests
 .....
 
 - Sorted out test failures happening due to a small numerical difference of the
-  results from the PyPI-installed ``srwpy`` in the Sirepo Docker.
+  results from the PyPI-installed ``srwpy`` in the Sirepo Docker image.
 - Removed an old/irrelevant test.
 
 CI improvements

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -10,7 +10,7 @@ This is a maintenance release with small API, tests, CI, and documentation updat
 API
 ...
 
-- Enabled generation beamline elements from existing simulations.
+- Enabled generation of beamline elements from existing simulations.
 - Moved and updated the ``prepare_*_env.py`` code from the ``examples/``
   directory of the repository to the library code, so that the new module can be
   imported in IPython and Jupyter notebooks (both interactively and in the docs).

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -20,7 +20,7 @@ API
 Documentation
 .............
 
-- Pinned ``furo`` minimum version to 2023.8.17 to compatiblity with Sphinx 7.2.0
+- Pinned ``furo`` minimum version to 2023.8.17 for compatiblity with Sphinx 7.2.0
   and 7.2.1.
 
 Tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,6 @@ matplotlib
 nbsphinx
 numpydoc
 pandoc
-sphinx==7.1.2
+sphinx>=7.2.2
 sphinx-copybutton
 tabulate>=0.9.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,13 +9,13 @@ pytest
 vcrpy>=4.3.1
 # These are dependencies of various sphinx extensions for documentation.
 # cloud-sptheme
-furo
+furo>=2023.8.17
 ipython
 jupyter
 matplotlib
 nbsphinx
 numpydoc
 pandoc
-sphinx>=7.2.2
+sphinx
 sphinx-copybutton
 tabulate>=0.9.0


### PR DESCRIPTION
## What's Changed
* Generate beamline elements by @rlb131 in https://github.com/NSLS-II/sirepo-bluesky/pull/136
* Better way to prepare bluesky environment by @mrakitin in https://github.com/NSLS-II/sirepo-bluesky/pull/141

Also in this PR:
- includes a minimum pin of `sphinx` v7.2.2 due to https://github.com/pradyunsg/furo/discussions/693#discussioncomment-6753629
- change building docs with Python 3.10 as the missing `doct` v1.1.0 was published on PyPI: https://pypi.org/project/doct/1.1.0/.