### PR TITLE
TST: fix comparison of mean value of images with expected value

### DIFF
--- a/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
+++ b/sirepo_bluesky/tests/test_bl_elements_as_ophyd_objs.py
@@ -309,7 +309,7 @@ def test_shadow_with_run_engine(RE, db, shadow_tes_simulation, num_steps=5):
 
     # Check that an average values of the first and last images are right:
     assert np.allclose(w9_image[0].mean(), 0.0)
-    assert np.allclose(w9_image[-1].mean(), 0.255665516042795)
+    assert np.allclose(w9_image[-1].mean(), 0.255665516042795, atol=1e-3)
 
     # Check that the values from the table and averages from the image data are
     # the same:


### PR DESCRIPTION
A simple fix to resolve failing runs on schedule.
A similar solution is implemented within #112 (we'll resolve the conflicts in that PR after merging this one).